### PR TITLE
feature/update-application-use-node-24

### DIFF
--- a/.github/workflows/dev-uat-live--build-image--on-commit.yml
+++ b/.github/workflows/dev-uat-live--build-image--on-commit.yml
@@ -43,6 +43,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
     - name: Install all the pre-requisites
       run: npm ci
 
@@ -68,12 +72,14 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: naturescot/cross-service-pages
       run: docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/} .
+           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/} $ECR_REGISTRY/$ECR_REPOSITORY:prerelease
 
     - name: Push the Docker Image to Amazon ECR
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: naturescot/cross-service-pages
       run: docker push $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/}
+           docker push $ECR_REGISTRY/$ECR_REPOSITORY:prerelease
 
     - name: Logout of Amazon ECR
       if: always()

--- a/.github/workflows/dev-uat-live--build-image--on-commit.yml
+++ b/.github/workflows/dev-uat-live--build-image--on-commit.yml
@@ -41,7 +41,7 @@ jobs:
       ENVIRONMENT: ${{ needs.determine-environment.outputs.environment }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Install all the pre-requisites
       run: npm ci
@@ -53,7 +53,7 @@ jobs:
       run: npm prune --production
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -61,7 +61,7 @@ jobs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Build and tag the Docker Image
       env:

--- a/.github/workflows/dev-uat-live--build-image--on-commit.yml
+++ b/.github/workflows/dev-uat-live--build-image--on-commit.yml
@@ -71,15 +71,17 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: naturescot/cross-service-pages
-      run: docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/} .
-           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/} $ECR_REGISTRY/$ECR_REPOSITORY:prerelease
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/} .
+        docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/} $ECR_REGISTRY/$ECR_REPOSITORY:prerelease
 
     - name: Push the Docker Image to Amazon ECR
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: naturescot/cross-service-pages
-      run: docker push $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/}
-           docker push $ECR_REGISTRY/$ECR_REPOSITORY:prerelease
+      run: |
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:${GITHUB_REF##*/}
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:prerelease
 
     - name: Logout of Amazon ECR
       if: always()

--- a/.github/workflows/dev-uat-live--build-image--on-commit.yml
+++ b/.github/workflows/dev-uat-live--build-image--on-commit.yml
@@ -44,8 +44,8 @@ jobs:
     - uses: actions/checkout@v6
 
     - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
+      with:
+        node-version: '24'
 
     - name: Install all the pre-requisites
       run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Builder Stage
 ################################################################################
 
-# we're deploying to the 20-alpine image, so do our building on it too
-FROM node:20-alpine as builder
+# we're deploying to the 24-alpine image, so do our building on it too
+FROM node:24-alpine AS builder
 
 # node-gyp runs as part of the npm install, so we need to install dependencies
 # we need git for cypress as it's using a custom version of requests that
@@ -31,8 +31,8 @@ RUN npm ci && npm prune --production
 # Deployable Image
 ################################################################################
 
-# we built on the 20-alpine image, so we need to deploy on it too
-FROM node:20-alpine
+# we built on the 24-alpine image, so we need to deploy on it too
+FROM node:24-alpine
 
 # drop back to the non-privileged user for run-time
 WORKDIR /home/node
@@ -48,8 +48,8 @@ RUN mkdir -p ./dist
 
 # these variables are for overriding but keep them consistent between image and
 # run
-ENV CSP_PORT 3004
-ENV CSP_PATH_PREFIX cross-service-pages
+ENV CSP_PORT=3004
+ENV CSP_PATH_PREFIX=cross-service-pages
 
 # let docker know about our listening port
 EXPOSE $CSP_PORT

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cy:open": "cypress open"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "bugs": {
     "url": "https://github.com/Scottish-Natural-Heritage/cross-service-pages/issues"


### PR DESCRIPTION
Node.js 20 reached end-of-life at the end of April.

Updates the Dockerfile to use the `node:24-alpine` image for building and deploying, and updates the `engine` field in package.json to `24`.

Fixes the `LegacyKeyValueFormat` warning in the logs.
Fixes the `FromAsCasing` warning in the logs.

Updates any Actions used in the workflow to their latest versions.

Updates the workflow to push a `prerelease` tagged image too, and to use Node.js 24 for the app build on the runner.