### PR TITLE
updated privacy policy to include muirburn

### DIFF
--- a/src/views/privacy-policy.njk
+++ b/src/views/privacy-policy.njk
@@ -18,6 +18,7 @@
         <li>Gulls health and safety: <a class="govuk-link" href="https://licensing.nature.scot/gulls-health-and-safety/intro">https://licensing.nature.scot/gulls-health-and-safety/intro</a></li>
         <li>Gulls health and safety (returns): <a class="govuk-link" href="https://licensing.nature.scot/gulls-health-and-safety-return/intro">https://licensing.nature.scot/gulls-health-and-safety-return/intro</a></li>
         <li>Land on which red grouse may be killed or taken: <a class="govuk-link" href="https://licensing.nature.scot/red-grouse/apply">https://licensing.nature.scot/red-grouse/apply</a></li>
+        <li>Muirburn: <a class="govuk-link" href="https://licensing.nature.scot/muirburn/apply">https://licensing.nature.scot/muirburn/apply</a></li>
       </ul>
 
       <h2 class="govuk-heading-m">Who collects your personal data</h2>
@@ -114,7 +115,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>licensed activities and purposes</li>
         <li>species</li>
-        <li>geographic data</li>
+        <li>geographic data (for example, licence boundaries for muirburn)</li>
         <li>total number of licences issued for a period (for example, a month or year)</li>
         <li>reports and returns</li>
       </ul>
@@ -172,6 +173,8 @@
       </ul>
 
       <p class="govuk-body">We retain the postcode and use this to model species populations and assess the effectiveness of licensed activities. If you do not want NatureScot to retain your postcode, you must inform us.</p>
+
+      <p class="govuk-body">Survey data you submit with a muirburn application will be retained in line with our licensing retention policy.</p>
 
       <h2 class="govuk-heading-m">What happens if you do not provide the data</h2>
 


### PR DESCRIPTION
This PR adds back in the privacy policy info for muirburn. It is a reverse of [PR #64 ](https://github.com/Scottish-Natural-Heritage/cross-service-pages/pull/69/files).